### PR TITLE
Get material by name

### DIFF
--- a/examples/make_toroidal_model_example.py
+++ b/examples/make_toroidal_model_example.py
@@ -27,18 +27,18 @@ PbLi.set_density("g/cm3", 9.806)
 materials = openmc.Materials([RAFM, PbLi, W])
 
 build = {
-    "sol": {"thickness": 5, "material": None, "description": "Vacuum"},
-    "FW": {"thickness": 4, "material": RAFM, "description": RAFM.name},
-    "Breeder": {"thickness": 20, "material": PbLi, "description": PbLi.name},
+    "sol": {"thickness": 5, "description": "Vacuum"},
+    "FW": {"thickness": 4, "material_name": RAFM.name, "description": RAFM.name},
+    "Breeder": {"thickness": 20, "material_name": PbLi.name, "description": PbLi.name},
     "bogus layer": {
         "thickness": 0,
         "description": "this layer will be skipped due to zero thickness",
     },
-    "shield": {"thickness": 20, "material": W, "description": W.name},
+    "shield": {"thickness": 20, "material_name": W.name, "description": W.name},
 }
 
 toroidal_model = ToroidalModel(
-    build, major_radius, plasma_minor_z_radius, plasma_minor_xy_radius
+    build, major_radius, plasma_minor_z_radius, plasma_minor_xy_radius, materials
 )
 model, cells = toroidal_model.get_openmc_model()
 model.export_to_model_xml()
@@ -47,3 +47,4 @@ model.export_to_model_xml()
 rbp = RadialBuildPlot(build, title="Toroidal Model Example", size=(4, 3))
 rbp.plot_radial_build()
 rbp.to_png()
+

--- a/radial_build_tools.py
+++ b/radial_build_tools.py
@@ -283,11 +283,8 @@ class ToroidalModel(object):
         self.minor_rad_xy = minor_rad_xy
         if isinstance(materials, str):
             self.input_materials = openmc.Materials.from_xml(materials)
-            self.materials_path = materials
         else:
             self.input_materials = materials
-            self.materials_path = Path.cwd() / "input_materials.xml"
-            materials.export_to_xml(self.materials_path)
 
         self.assign_materials()
 
@@ -296,14 +293,14 @@ class ToroidalModel(object):
         Assign OpenMC material objects to each layer in the build dict
         """
         for layer_name, layer_data in self.build.items():
-            if "material" in layer_data:
+            if "material_name" in layer_data:
                 layer_data["material"] = self.get_material_by_name(
                     layer_data["material_name"]
                 )
             else:
                 layer_data["material"] = None
 
-    def get_material_by_name(self, material):
+    def get_material_by_name(self, material_name):
         """
         Search the materials object for a material with a matching name. Openmc
         allows duplicate names, and names are not required, be advised.
@@ -316,12 +313,12 @@ class ToroidalModel(object):
             mat (OpenMC material object): material object with matching name
         """
         for mat in self.input_materials:
-            if mat.name == material:
+            if mat.name == material_name:
                 return mat
         # if this returns none, openmc will just assign vacuum to any cell
         # using this material
         raise ValueError(
-            f"no material name {material} was found in the library"
+            f"no material name {material_name} was found in the library"
         )
 
     def build_surfaces(self):

--- a/radial_build_tools.py
+++ b/radial_build_tools.py
@@ -1,6 +1,5 @@
 import yaml
 import argparse
-from pathlib import Path
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 import matplotlib.colors


### PR DESCRIPTION
Step one towards adding full yml input support/mix by volume support to the model building tool. This PR changes the the input slightly so it uses the material name rather than the material object itself, then retrieves the material object from the library associated with the model. Using the name rather than the object itself makes it easier to use a pre-existing library.