### PR TITLE
Plot functionality update to include equal IB and OB sizes

### DIFF
--- a/examples/ExampleRadialBuild.yml
+++ b/examples/ExampleRadialBuild.yml
@@ -2,23 +2,27 @@ title: Example Radial Build
 
 build:
   sol:
-    thickness: [8,9.2]
+    thickness: 9
     color: '#acc2d9'
   FW_armor:
-    thickness: [0.2,0.3]
+    thickness: 0.2
     color: '#56ae57'
   FW:
-    thickness: [3.8,4.5]
+    thickness: 4.5
     composition:
       MF82H: 0.34
       HeT410P80: 0.66
     color: '#b2996e'
   breeder:
     description: Composition and thickness vary
+<<<<<<< HEAD
     thickness: [5,30]
+=======
+    thickness: 10
+>>>>>>> ac2cc21 (One plot for same ib/ob size)
     color: '#a8ff04'
   BW:
-    thickness: [2,3]
+    thickness: 3
     composition:
       MF82H: 0.8
       HeT410P80: 0.2
@@ -67,7 +71,7 @@ build:
       Void: 1.0
     color: '#4c9085'
   Coil Pack:
-    thickness: [52.5,52.5]
+    thickness: 52.5
     composition:
       SS316L: 0.7435
       HTS TAPE: 0.0622

--- a/radial_build_tools.py
+++ b/radial_build_tools.py
@@ -248,6 +248,21 @@ class RadialBuildPlot(object):
         return text, visual_thickness
 
 
+    def ib_ob_are_identical(self):
+        """
+        Check whether the inboard and outboard radial builds are identical.
+
+        Returns
+        -------
+        bool
+            True if every layer has the same inboard and outboard thickness,
+            False otherwise.
+        """
+        return all(
+            layer["inboard"] == layer["outboard"]
+            for layer in self.build.values()
+        )
+
     def plot_side(self, ax, side, reverse=False):
         """
         Plot either the inboard or outboard radial build.
@@ -320,25 +335,36 @@ class RadialBuildPlot(object):
         """
         Creates radial build plots for both the inboard and outboard sides.
         """
+        if self.ib_ob_are_identical():
+            fig,ax =plt.subplots(
+                1,
+                1,
+                figsize=(self.size[0],self.size[1] / 2),
+            )
+            self.plot_side(
+                ax,
+                side = "inboard",
+                reverse= True,
+            )
 
-        fig, axes = plt.subplots(
-            2,
-            1,
-            figsize=(self.size[0], self.size[1]),
-        )
+        else:
+            fig, axes =plt.subplots(
+                2,
+                1,
+                figsize=(self.size[0],self.size[1]),
+            )
+            self.plot_side(
+                axes[0],
+                side="outboard",
+                reverse=False,
+            )
+            self.plot_side(
+                axes[1],
+                side="outboard",
+                reverse= "False",
+            )
 
-        self.plot_side(
-            axes[0],
-            side="inboard",
-            reverse=True,
-        )
-
-        self.plot_side(
-            axes[1],
-            side="outboard",
-            reverse=False,
-        )
-
+        fig.suptitle(self.title, y=1,fontsize =26)
         fig.suptitle(self.title, y=1,fontsize =26)
         plt.subplots_adjust(hspace=0.12, top=0.88, bottom=0.06)
 

--- a/radial_build_tools.py
+++ b/radial_build_tools.py
@@ -11,6 +11,7 @@ import textwrap
 import random
 
 
+
 def expand_ib_ob(build):
     """
     Read a radial build dictionary and populate members "inboard" and "outboard"
@@ -92,6 +93,7 @@ class RadialBuildPlot(object):
 
 
 
+
     def assign_colors(self):
         """
         Assign colors to each layer in the build definition using a two-phase approach:
@@ -153,10 +155,11 @@ class RadialBuildPlot(object):
         ]
         comp_text = ", ".join(mat_strings)
 
-        comp_string = textwrap.fill(
-            comp_text,
-            width=self.max_characters,
-        ) + "\n"
+        comp_string = (textwrap.fill(comp_text,
+        width=self.max_characters,
+            )
+            + "\n"
+        )
 
         return comp_string
 
@@ -178,8 +181,18 @@ class RadialBuildPlot(object):
             yaml.safe_dump(data_dict, file, default_flow_style=False, sort_keys=False)
 
     def get_layer_string(self, name, layer, side=None):
+    def get_layer_string(self, name, layer, side=None):
         """
         Processes a layer in the radial build dict to get formatted text for
+        the plot.
+         Arguments:
+        name (str):
+            Name of the layer.
+        layer (dict):
+            Dictionary containing the layer definition.
+        side (str, optional):
+            Which side of the radial build to use when selecting the
+            thickness.
         the plot.
          Arguments:
         name (str):
@@ -197,14 +210,19 @@ class RadialBuildPlot(object):
         min_line_height = 5
 
 
+
         thickness_str = ""
         thickness = layer[side]
         thickness_str = f': {thickness} {self.unit}'
 
+        thickness= layer[side]
+        thickness_str = f": {thickness} {self.unit}"
+        visual_thickness = thickness
 
         comp_string = ""
         if "composition" in layer:
             comp_string = self.build_composition_string(layer["composition"])
+
 
         description_str = ""
         if "description" in layer:
@@ -212,6 +230,7 @@ class RadialBuildPlot(object):
                 f'{layer["description"]}',
                 self.max_characters,
                 drop_whitespace=False,
+            )
             )
 
         text = f"{name}{thickness_str}\n{comp_string}\n{description_str}".rstrip()
@@ -222,7 +241,12 @@ class RadialBuildPlot(object):
         
         visual_thickness = min(max(thickness, min_thickness), self.max_thickness) 
 
+        visual_thickness = (
+            min(max(visual_thickness, min_thickness), self.max_thickness)
+        )
+
         return text, visual_thickness
+
 
     def plot_side(self, ax, side, reverse=False):
         """
@@ -246,10 +270,14 @@ class RadialBuildPlot(object):
 
         for (name, layer), color in zip(layers, colors):
             thickness = layer[side]
+            thickness = layer[side]
             if thickness == 0:
                 continue
 
             layer_str, visual_thickness = self.get_layer_string(
+                name,
+                layer,
+                side,
                 name,
                 layer,
                 side,
@@ -387,6 +415,7 @@ class ToroidalModel(object):
 
     def __init__(self, build, major_rad, minor_rad_z, minor_rad_xy, materials):
         self.build = expand_ib_ob(build)
+        self.build = expand_ib_ob(build)
         self.major_rad = major_rad
         self.minor_rad_z = minor_rad_z
         self.minor_rad_xy = minor_rad_xy
@@ -495,6 +524,7 @@ class ToroidalModel(object):
                     name=layer,
                     fill=layer_def["material"],
                 )
+            materials.add(layer_def["material"])
             materials.add(layer_def["material"])
 
         self.cell_list = list(cell_dict.values())


### PR DESCRIPTION
The existing plot function was creating two different inboard and outboard plots twice.
This PR change is so that a single plot is created when the user decides to have the same size for both ib and ob.